### PR TITLE
Fix type-o in the base install.yaml storageClassName

### DIFF
--- a/base/install.yaml
+++ b/base/install.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       accessModes:
         - ReadWriteOnce
-      storageClassName: deafault
+      storageClassName: default
       # NOTE: You can increase the storage size
       resources:
         requests:


### PR DESCRIPTION
## Change Summary
Fix type-o in the `storageClassName` of the base `install.yaml` file, from `deafault` => `default`.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
