### PR TITLE
Make cluster auto-recover

### DIFF
--- a/base/install.yaml
+++ b/base/install.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: typesense
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     app: typesense
   ports:
@@ -80,7 +81,7 @@ spec:
       containers:
       - name: typesense
         # NOTE : you can update to the latest release
-        image: typesense/typesense:0.22.1
+        image: typesense/typesense:0.25.0
         command:
           - "/opt/typesense-server"
           - "-d"
@@ -92,10 +93,24 @@ spec:
           - "--peering-port"
           - "8107"
           - "--nodes"
-          - "/usr/share/typesense/nodes"
+          - "/usr/share/typesense/nodes"          
+          - "--healthy-read-lag"
+          - "500"
+          - "--healthy-write-lag"
+          - "500"
+          - "--reset-peers-on-error"
         ports:
         - containerPort: 8108
           name: http
+        readinessProbe:
+            httpGet:
+              path: /health
+              port: 8108
+            initialDelaySeconds: 1
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 5
         # NOTE: you can increase these resources
         resources:
           requests:


### PR DESCRIPTION
With these changes (and the update to v0.25) this setup should finally reliably work.

* The reset-peers flag is needed to recover from pod IP changes
* read/write-lag flags are made explicit as, depending on cluster topology, folks will want different values here
* a readiness probe fixes consumers hitting dead nodes and causing even more issues
* the `publishNotReadyAddresses` setting ensures that pod IPs are still available for clustering