### PR TITLE
Fix overlay ConfigMap nodeslist name typo

### DIFF
--- a/overlays/dev/kustomization.yaml
+++ b/overlays/dev/kustomization.yaml
@@ -40,7 +40,7 @@ patches:
 # Add to the nodes list here if you change the number of replicas in statefulset
 - target:
     kind: ConfigMap
-    name: nodelist
+    name: nodeslist
   patch: |-
     - op: replace
       path: /data/nodes


### PR DESCRIPTION
## Change Summary
Update name `nodelist` to `nodeslist` because is the ConfigMap name created from `base/install.yaml`
